### PR TITLE
Fixed a bug about member access in tart.Builder.

### DIFF
--- a/tart/Builder.js
+++ b/tart/Builder.js
@@ -36,7 +36,7 @@ tart.Builder = function(id) {
 
 /**
  * @type {jQueryObject}
- * @protected
+ * @private
  */
 tart.Builder.prototype.$dom_ = null;
 


### PR DESCRIPTION
Previously, developers got null when they tried to access the dom via builder.getDOM().
