### PR TITLE
[Components] Typo fixed in tart.ui.DlgComponent from reqiure to require

### DIFF
--- a/tart/ui/DlgComponent.js
+++ b/tart/ui/DlgComponent.js
@@ -24,7 +24,7 @@
 goog.provide('tart.ui.DlgComponent');
 goog.require('goog.dom.query');
 goog.require('tart.ui.ComponentManager');
-goog.reqiure('goog.events.EventTarget');
+goog.require('goog.events.EventTarget');
 
 
 /**


### PR DESCRIPTION
Typo was found in line 27
This typo prevented execution of Dlgcomponent.js with error "Uncaught TypeError: Object #<Object> has no method 'reqiure'"
