### PR TITLE
[components] Changed DlgComponent's getElement's return value type.

### DIFF
--- a/tart/ui/DlgComponent.js
+++ b/tart/ui/DlgComponent.js
@@ -44,7 +44,7 @@ goog.inherits(tart.ui.DlgComponent, goog.events.EventTarget);
 
 /**
  * Returns the dom element attached with the Component instance.
- * @return {?Node}
+ * @return {?Element}
  */
 tart.ui.DlgComponent.prototype.getElement = function() {
     var rv = this.element;


### PR DESCRIPTION
from Node to Element. It's wrong for it to have a Node as a root element, right?
