### PR TITLE
Added hidden input to prevent document.write to overcome all other dom elements.

### DIFF
--- a/tart/mvc/Application.js
+++ b/tart/mvc/Application.js
@@ -64,9 +64,10 @@ tart.mvc.Application = function(dom) {
             throw new tart.Err('No default route is set.', 'tartMVC Application Exception');
 
         var historyCallback, that = this;
+        var hiddenInput = tart.dom.createElement('input');
 
         /** @private */
-        this.history_ = new goog.History(false);
+        this.history_ = new goog.History(false, false, hiddenInput);
         this.initRouting();
 
         /**


### PR DESCRIPTION
This bug was emptying all body elements after history state holder input written to it.
