### PR TITLE
[JSDoc] Fixed return types

### DIFF
--- a/tart/base/plugin/Pager.js
+++ b/tart/base/plugin/Pager.js
@@ -134,7 +134,7 @@ tart.base.plugin.Pager.prototype.getCurrentPage = function() {
 
 
 /**
- * @return {number} Whether there is a previous page available.
+ * @return {boolean} Whether there is a previous page available.
  */
 tart.base.plugin.Pager.prototype.hasPrev = function() {
     return this.pagination_.hasPrev();
@@ -142,7 +142,7 @@ tart.base.plugin.Pager.prototype.hasPrev = function() {
 
 
 /**
- * @return {number} Whether there is a next page available.
+ * @return {boolean} Whether there is a next page available.
  */
 tart.base.plugin.Pager.prototype.hasNext = function() {
     return this.pagination_.hasNext();


### PR DESCRIPTION
Fixed wrong JSDoc at Pager.js for hasNext and hasPrev functions.
