### PR TITLE
[RevealingPassword] Focuses onto input element after type changes.

### DIFF
--- a/tart/ui/input/RevealingPassword.js
+++ b/tart/ui/input/RevealingPassword.js
@@ -68,6 +68,7 @@ tart.ui.input.RevealingPassword.prototype.toggleDisplay = function() {
         passwordArea.type = 'text';
     else
         passwordArea.type = 'password';
+    passwordArea.focus();
 };
 
 


### PR DESCRIPTION
Due to problems occured within various browsers, revealingPassword
component needs to focus onto input element after typoe changes.
In other cases, style changes are not being applied correctly.
