### PR TITLE
Fix gulp gh-pages task override gh-pages branch issue.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,18 +1,26 @@
 var gulp = require('gulp');
 var shell = require("gulp-shell");
-var ghPages = require('gulp-gh-pages');
 var runSequence = require('run-sequence');
+
+var GH_TOKEN = process.env.GH_TOKEN || '';
 
 gulp.task('jsdoc', shell.task([
     'rm -rf ./docs',
     'jsdoc -c ./scripts/jsdoc-conf.json'
 ]));
 
-gulp.task('gh-pages', ['jsdoc'], function() {
-    var GH_TOKEN = process.env.GH_TOKEN || '';
-    return gulp.src('./docs/**/*').
-                pipe(ghPages({ remoteUrl: 'https://' + GH_TOKEN + '@github.com/tart/tartJS.git' }));	
-});
+gulp.task('gh-pages', ['jsdoc'], shell.task([
+    'mv docs docs_new',
+    'git remote add upstream https://' + GH_TOKEN + '@github.com/tart/tartJS.git/',
+    'git fetch upstream',
+    'git checkout -b gh-pages upstream/gh-pages',
+    'rm -rf docs',
+    'mv docs_new docs',
+    'git add docs',
+    'git commit -m "Update documentation"',
+    'git push upstream gh-pages',
+    'git checkout master'
+]));
 
 gulp.task('travis-master', ['gh-pages']);
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   "dependencies": {},
   "devDependencies": {
     "gulp": "^3.9.0",
-    "gulp-gh-pages": "^0.5.2",
     "gulp-shell": "^0.4.2",
     "jaguarjs-jsdoc": "git://github.com/davidshimjs/jaguarjs-jsdoc",
     "jsdoc": "^3.3.2",


### PR DESCRIPTION
`gulp gh-pages` task was overriding whole `gh-pages` branch instead of just updating `docs` folder. This PR fixes that issue.
